### PR TITLE
Implement minDate/maxDate filters

### DIFF
--- a/appengine/models/activity_record.py
+++ b/appengine/models/activity_record.py
@@ -1,6 +1,8 @@
 from google.appengine.ext import ndb
 from endpoints_proto_datastore.ndb import EndpointsModel
+from endpoints_proto_datastore.ndb import EndpointsAliasProperty
 from datetime import datetime
+from protorpc import messages
 
 from models import ActivityPost
 
@@ -87,6 +89,31 @@ class ActivityRecord(EndpointsModel):
 
     #  activity type metadata
     metadata = ndb.StructuredProperty(ActivityMetaData, repeated=True)
+
+    def MinDateSet(self, value):
+        if value is not None:
+            self._endpoints_query_info._filters.add(ActivityRecord.post_date >= value)
+
+    @EndpointsAliasProperty(setter=MinDateSet, property_type=messages.StringField)
+    def minDate(self):
+        """
+        minDate is only used as parameter in query_methods
+        so there should never be a reason to actually retrieve the value
+        """
+        return None
+
+    def MaxDateSet(self, value):
+        if value is not None:
+            self._endpoints_query_info._filters.add(ActivityRecord.post_date <= value)
+
+    @EndpointsAliasProperty(setter=MaxDateSet, property_type=messages.StringField)
+    def maxDate(self):
+        """
+        maxDate is only used as parameter in query_methods
+        so there should never be a reason to actually retrieve the value
+        """
+        return None
+
 
     def calculate_impact(self):
         self.plus_oners = 0

--- a/appengine/services/web_endpoints.py
+++ b/appengine/services/web_endpoints.py
@@ -24,7 +24,8 @@ class ActivityRecordService(remote.Service):
         activity_record.put()
         return activity_record
 
-    @ActivityRecord.query_method(query_fields=('limit', 'order', 'pageToken', 'gplus_id'),
+    @ActivityRecord.query_method(query_fields=('limit', 'order', 'pageToken', 'gplus_id',
+                                               'minDate', 'maxDate'),
                                  path='activityRecord', name='list')
     def ActivityRecordList(self, query):
         return query


### PR DESCRIPTION
Implementation of https://github.com/maiera/gde-app/issues/39

minDate/maxDate parameters have to be supplied as String in YYYY/MM/DD format (same format as post_date is stored in).
Other values won't cause a problem either because post_date is a StringProperty (not sure if we want to keep it like this or use DateProperty instead?) so string comparison is used. It's also possible to use e.g. maxDate=2013 to get all activities up to the end of 2012. (since '2012/03/31' <= '2013' but '2013/01/01' > '2013')
