### PR TITLE
Add update/delete endpoints

### DIFF
--- a/appengine/services/web_endpoints.py
+++ b/appengine/services/web_endpoints.py
@@ -25,6 +25,31 @@ class ActivityRecordService(remote.Service):
         activity_record.put()
         return activity_record
 
+    @ActivityRecord.method(path='/activityRecord/{id}', http_method='PUT',
+                           name='update')
+    def ActivityRecordUpdate(self, activity_record):
+        if not activity_record.from_datastore:
+            raise endpoints.NotFoundException('ActivityRecord not found.')
+        activity_record.put()
+        return activity_record
+
+    @ActivityRecord.method(path='/activityRecord/{id}', http_method='PATCH',
+                           name='patch')
+    def ActivityRecordPatch(self, activity_record):
+        if not activity_record.from_datastore:
+            raise endpoints.NotFoundException('ActivityRecord not found.')
+        activity_record.put()
+        return activity_record
+
+    @ActivityRecord.method(request_fields=('id',), response_fields=('id',),
+                           path='/activityRecord/{id}',
+                           http_method='DELETE', name='delete')
+    def ActivityRecordDelete(self, activity_record):
+        if not activity_record.from_datastore:
+            raise endpoints.NotFoundException('ActivityRecord not found.')
+        activity_record.key.delete()
+        return activity_record
+
     @ActivityRecord.query_method(query_fields=('limit', 'order', 'pageToken', 'gplus_id',
                                                'minDate', 'maxDate'),
                                  path='activityRecord', name='list')


### PR DESCRIPTION
This will allow manual edits from the front-end, like adding metadata to existing records. (Necessary for https://github.com/maiera/gde-app/issues/13)

Some things to consider with the endpoints-proto-datastore library we are using.
-  There is currently no difference between update/patch methods, both of them do a `patch` internally, but,
- Repeated properties (like metadata) have to be always supplied in the post body, otherwise any existing values will be replaced

See: https://github.com/GoogleCloudPlatform/endpoints-proto-datastore/issues/65
