### PR TITLE
Fix insert endpoint paths

### DIFF
--- a/appengine/services/web_endpoints.py
+++ b/appengine/services/web_endpoints.py
@@ -60,7 +60,7 @@ class ActivityRecordService(remote.Service):
 @api_root.api_class(resource_name='activity_post', path='activityPost')
 class ActivityPostService(remote.Service):
 
-    @ActivityPost.method(path='/activityPost', http_method='POST',
+    @ActivityPost.method(path='/activityPost/{id}', http_method='POST',
                          name='insert')
     def insert(self, activity_post):
         activity_post.put()


### PR DESCRIPTION
Since `id` is actually the auto-generated datastore key having to specify it for new AR/AP doesn't make sense in my opinion, and actually makes inserting new data via the API more complicated since you have to "invent" an ID.

Inserts without an ID in the path is also default for all discovery-based Google APIs.
