### PR TITLE
Add activity_type and product_group endpoints (PR part 2)

### DIFF
--- a/appengine/models/activity_post.py
+++ b/appengine/models/activity_post.py
@@ -5,16 +5,8 @@ from endpoints_proto_datastore.ndb import EndpointsModel
 from endpoints_proto_datastore.ndb import EndpointsAliasProperty
 from endpoints_proto_datastore.ndb import EndpointsVariantIntegerProperty
 from protorpc import messages
-
-ACTIVITY_TYPES = ["#bugreport", "#article", "#blogpost", "#book", "#techdocs",
-                  "#translation", "#techtalk", "#opensourcecode",
-                  "#forumpost", "#community", "#video", "#tutorial", "#interview"];
-
-PRODUCT_GROUPS = ["#android", "#admob", "#adwords", "#angularjs", "#chrome",
-                  "#dart", "#dartlang", "#cloudplatform", "#googleanalytics",
-                  "#googleappsapi","#googleappsscript", "#googledrive",
-                  "#glass", "#googlemapsapi", "#googleplus", "#youtube",
-                  "#uxdesign"];
+from models import ActivityType
+from models import ProductGroup
 
 class ActivityPost(EndpointsModel):
 
@@ -87,7 +79,7 @@ class ActivityPost(EndpointsModel):
     def get_activity_types(self, content):
         """Extract activity type hashtags."""
         at = []
-        for activity_type in ACTIVITY_TYPES:
+        for activity_type in ActivityType.all_tags():
             result = re.search(activity_type, content, flags=re.IGNORECASE)
             if result is not None:
                 at.append(activity_type)
@@ -96,7 +88,7 @@ class ActivityPost(EndpointsModel):
     def get_product_groups(self, content):
         """Extract product group hashtags."""
         pg = []
-        for product_group in PRODUCT_GROUPS:
+        for product_group in ProductGroup.all_tags():
             result = re.search(product_group, content, flags=re.IGNORECASE)
             if result is not None:
                 pg.append(product_group)
@@ -111,6 +103,3 @@ class ActivityPost(EndpointsModel):
                     links += ", "
                 links += attachment["url"]
         return links
-
-
-

--- a/appengine/services/gplus.py
+++ b/appengine/services/gplus.py
@@ -26,15 +26,6 @@ from models import activity_record as ar
 
 API_KEY = 'AIzaSyBVCJKggp_1VBIC2xisWCWrX-VR-Dih694'
 
-ACTIVITY_TYPES = ["#bugreport", "#article", "#blogpost", "#book", "#techdocs",
-                  "#translation", "#techtalk", "#opensourcecode",
-                  "#forumpost", "#community", "#video", "#tutorial", "#interview"];
-
-PRODUCT_GROUPS = ["#android", "#admob", "#adwords", "#angularjs", "#chrome",
-                  "#dart", "#dartlang", "#cloudplatform", "#googleanalytics",
-                  "#googleappsapi","#googleappsscript", "#googledrive",
-                  "#glass", "#googlemapsapi", "#googleplus", "#youtube",
-                  "#uxdesign"];
 
 class UpdateActivityPosts(webapp2.RequestHandler):
 

--- a/appengine/services/utils.py
+++ b/appengine/services/utils.py
@@ -28,17 +28,6 @@ from models import activity_record as ar
 
 API_KEY = 'AIzaSyBVCJKggp_1VBIC2xisWCWrX-VR-Dih694'
 
-ACTIVITY_TYPES = ["#bugreport", "#article", "#blogpost", "#book", "#techdocs",
-                  "#translation", "#techtalk", "#opensourcecode",
-                  "#forumpost", "#community", "#video", "#tutorial", "#interview"]
-
-PRODUCT_GROUPS = ["#android", "#admob", "#adwords", "#angularjs", "#chrome",
-                  "#dart", "#dartlang", "#cloudplatform", "#googleanalytics",
-                  "#googleappsapi", "#googleappsscript", "#googledrive",
-                  "#glass", "#googlemapsapi", "#googleplus", "#youtube",
-                  "#uxdesign"]
-
-
 my_default_retry_params = gcs.RetryParams(initial_delay=0.2,
                                           max_delay=5.0,
                                           backoff_factor=2,


### PR DESCRIPTION
Changes as per https://github.com/maiera/gde-app/issues/76

This PR actually switches to using the lists from datastore. Should only be deployed after the lists have been filled after https://github.com/maiera/gde-app/pull/91

/cc @SmokyBob @patt0 
