### PR TITLE
Logical deletion for Activity records

### DIFF
--- a/appengine/endpoints_proto_datastore/ndb/utils.py
+++ b/appengine/endpoints_proto_datastore/ndb/utils.py
@@ -42,6 +42,11 @@ COMPUTED_PROPERTY_EXPLANATION = (
     'A computed property can\'t be used to define an EndpointsModel. The type '
     'of the message field must be explicitly named; this can be done by using '
     'the property EndpointsComputedProperty.')
+JSON_PROPERTY_EXPLANATION = (
+    'A JSON property should not be used to define an EndpointsModel. Similar '
+    'functionality can be added by using a string property. For a nested '
+    'schema we recommend using ndb.StructuredProperty with other '
+    'EndpointsModel subclasses.')
 
 NDB_PROPERTY_TO_PROTO = {
     ndb.BlobKeyProperty: messages.StringField,
@@ -55,12 +60,14 @@ NDB_PROPERTY_TO_PROTO = {
     ndb.FloatProperty: messages.FloatField,
     ndb.GenericProperty: RaiseNotImplementedMethod(ndb.GenericProperty),
     ndb.IntegerProperty: messages.IntegerField,
-    ndb.JsonProperty: messages.BytesField,
+    ndb.JsonProperty: RaiseNotImplementedMethod(
+      ndb.JsonProperty,
+      explanation=JSON_PROPERTY_EXPLANATION),
     ndb.KeyProperty: messages.StringField,
     ndb.ModelKey: RaiseNotImplementedMethod(
         ndb.ModelKey,
         explanation=MODEL_KEY_EXPLANATION),
-    ndb.PickleProperty: messages.BytesField,
+    ndb.PickleProperty: messages.StringField,
     ndb.Property: RaiseNotImplementedMethod(ndb.Property),
     ndb.StringProperty: messages.StringField,
     ndb.TextProperty: messages.StringField,  # No concept of compressed here

--- a/appengine/index.yaml
+++ b/appengine/index.yaml
@@ -29,6 +29,19 @@ indexes:
 
 - kind: ActivityRecord
   properties:
+  - name: deleted
+  - name: post_date
+    direction: desc
+
+- kind: ActivityRecord
+  properties:
+  - name: deleted
+  - name: gplus_id
+  - name: post_date
+    direction: desc
+
+- kind: ActivityRecord
+  properties:
   - name: gplus_id
   - name: post_date
     direction: desc

--- a/appengine/models/activity_post.py
+++ b/appengine/models/activity_post.py
@@ -25,13 +25,15 @@ class ActivityPost(EndpointsModel):
     date = ndb.StringProperty()
     plus_oners = EndpointsVariantIntegerProperty(variant=messages.Variant.INT32)
     resharers = EndpointsVariantIntegerProperty(variant=messages.Variant.INT32)
-    comments = EndpointsVariantIntegerProperty(variant=messages.Variant.INT32) 
+    comments = EndpointsVariantIntegerProperty(variant=messages.Variant.INT32)
     title = ndb.StringProperty()
     # url of the post (question for stack overflow)
     url = ndb.StringProperty()
     product_group = ndb.StringProperty(repeated=True)
     activity_type = ndb.StringProperty(repeated=True)
     links = ndb.StringProperty()
+
+    deleted = ndb.BooleanProperty(default=False)
 
     def ApiKeySet(self, value):
         self._api_key = value

--- a/appengine/models/activity_record.py
+++ b/appengine/models/activity_record.py
@@ -158,7 +158,7 @@ class ActivityRecord(EndpointsModel):
 
     def IncludeDeletedSet(self, value):
         """
-        If value is true all timelineItems will be returned.
+        If value is true all activity records will be returned.
         Otherwise a filter for non-deleted items is necessary for the query.
         """
         if value is None or value is False:

--- a/appengine/services/update_gplus.py
+++ b/appengine/services/update_gplus.py
@@ -208,6 +208,12 @@ class TaskUpdateGplus(webapp2.RequestHandler):
         activities = ActivityPost.query(ActivityPost.gplus_id == gplus_id)
 
         for activity in activities:
+            # check if post belongs to deleted activity
+            activity_record = ar.find(activity)
+            if activity_record is not None:
+                if activity_record.deleted:
+                    continue
+
             # get the activity from gplus
             fields = 'id,verb,actor/id,annotation,object(id,actor/id,plusoners/totalItems,replies/totalItems,resharers/totalItems,content)'
             try:

--- a/appengine/services/update_gplus.py
+++ b/appengine/services/update_gplus.py
@@ -196,7 +196,7 @@ class TaskUpdateGplus(webapp2.RequestHandler):
     def post(self):
         """."""
         logging.info('tasks/upd_gplus')
-        
+
         bad_posts = []
         gplus_id = self.request.get('gplus_id')
         logging.info(gplus_id)
@@ -208,6 +208,9 @@ class TaskUpdateGplus(webapp2.RequestHandler):
         activities = ActivityPost.query(ActivityPost.gplus_id == gplus_id)
 
         for activity in activities:
+            if activity.deleted:
+                continue
+
             # check if post belongs to deleted activity
             activity_record = ar.find(activity)
             if activity_record is not None:

--- a/appengine/services/web_endpoints.py
+++ b/appengine/services/web_endpoints.py
@@ -8,6 +8,8 @@ from models import ActivityType
 from models import ProductGroup
 from models import ActivityGroup
 
+from google.appengine.ext import ndb
+
 from .utils import check_auth
 
 _CLIENT_IDs = [
@@ -72,8 +74,8 @@ class ActivityRecordService(remote.Service):
         return activity_record
 
     @ActivityRecord.method(request_fields=('id', 'api_key',), response_fields=('id',),
-                           path='/activityRecord/{id}',
-                           http_method='DELETE', name='delete')
+                           path='/activityRecord/trash/{id}',
+                           http_method='DELETE', name='trash')
     def ActivityRecordDelete(self, activity_record):
         if not activity_record.from_datastore:
             raise endpoints.NotFoundException('ActivityRecord not found.')
@@ -83,6 +85,29 @@ class ActivityRecordService(remote.Service):
 
         activity_record.deleted = True
         activity_record.put()
+
+        return activity_record
+
+    @ActivityRecord.method(request_fields=('id', 'api_key',), response_fields=('id',),
+                           path='/activityRecord/delete/{id}',
+                           http_method='DELETE', name='delete')
+    def ActivityRecordDelete(self, activity_record):
+        if not activity_record.from_datastore:
+            raise endpoints.NotFoundException('ActivityRecord not found.')
+
+        if not check_auth(activity_record.gplus_id, activity_record.api_key):
+            raise endpoints.UnauthorizedException('Only GDEs and admins may enter or change data.')
+
+        # Mark associated Activity Posts as deleted
+        if activity_record.gplus_posts is not None and len(activity_record.gplus_posts) > 0:
+            keys = [ndb.Key(ActivityPost, post_id) for post_id in activity_record.gplus_posts]
+            posts = ndb.get_multi(keys)
+            for post in posts:
+                if post is not None:
+                    post.deleted = True
+                    post.put()
+
+        activity_record.key.delete()
 
         return activity_record
 

--- a/appengine/services/web_endpoints.py
+++ b/appengine/services/web_endpoints.py
@@ -35,6 +35,9 @@ class ActivityRecordService(remote.Service):
         if not check_auth(activity_record.gplus_id, activity_record.api_key):
             raise endpoints.UnauthorizedException('Only GDEs and admins may enter or change data.')
 
+        if activity_record.deleted is None:
+            activity_record.deleted = False
+
         activity_record.put()
         return activity_record
 
@@ -47,6 +50,9 @@ class ActivityRecordService(remote.Service):
         if not check_auth(activity_record.gplus_id, activity_record.api_key):
             raise endpoints.UnauthorizedException('Only GDEs and admins may enter or change data.')
 
+        if activity_record.deleted is None:
+            activity_record.deleted = False
+
         activity_record.put()
         return activity_record
 
@@ -58,6 +64,9 @@ class ActivityRecordService(remote.Service):
 
         if not check_auth(activity_record.gplus_id, activity_record.api_key):
             raise endpoints.UnauthorizedException('Only GDEs and admins may enter or change data.')
+
+        if activity_record.deleted is None:
+            activity_record.deleted = False
 
         activity_record.put()
         return activity_record
@@ -72,11 +81,13 @@ class ActivityRecordService(remote.Service):
         if not check_auth(activity_record.gplus_id, activity_record.api_key):
             raise endpoints.UnauthorizedException('Only GDEs and admins may enter or change data.')
 
-        activity_record.key.delete()
+        activity_record.deleted = True
+        activity_record.put()
+
         return activity_record
 
     @ActivityRecord.query_method(query_fields=('limit', 'order', 'pageToken', 'gplus_id',
-                                               'minDate', 'maxDate'),
+                                               'minDate', 'maxDate', 'deleted', 'includeDeleted'),
                                  path='activityRecord', name='list')
     def ActivityRecordList(self, query):
         return query

--- a/appengine/services/web_endpoints.py
+++ b/appengine/services/web_endpoints.py
@@ -76,7 +76,7 @@ class ActivityRecordService(remote.Service):
     @ActivityRecord.method(request_fields=('id', 'api_key',), response_fields=('id',),
                            path='/activityRecord/trash/{id}',
                            http_method='DELETE', name='trash')
-    def ActivityRecordDelete(self, activity_record):
+    def ActivityRecordTrash(self, activity_record):
         if not activity_record.from_datastore:
             raise endpoints.NotFoundException('ActivityRecord not found.')
 


### PR DESCRIPTION
Implementation of https://github.com/maiera/gde-app/issues/99

Activity records now have a boolean field `deleted`
Calling `activity_record.delete` will set this field to `True` and store the record.
To undelete you call `activity_record.update` (with full AR information, same as you already do when saving entities from the frontend) and `deleted` set to `False`

`activity_record.list` by default only returns items with `deleted=False`

To get all activity_records you can use `includeDeleted=true` as query parameter.

To get only the deleted items you can use `includeDeleted=true&deleted=true`

When going live we have to set `deleted` to `False` for all existing entities in the datastore otherwise the result of activity_record.list would be empty.

I also changed the gplus update task to automatically skip posts if they are associated with a deleted activity_record.